### PR TITLE
Temporarily remove edit GitHub link

### DIFF
--- a/src/pages/guides/show_page.cr
+++ b/src/pages/guides/show_page.cr
@@ -3,11 +3,5 @@ class Guides::ShowPage < GuideLayout
 
   def content
     raw CustomMarkdownRenderer.render_to_html(@markdown)
-
-    div class: "rounded bg-grey-light p-5 mt-12" do
-      text "See a problem? Have an idea for improvement?"
-      text " "
-      link "Edit this page on GitHub", GitHubPath.for_file(@guide_file_path), target: "_blank"
-    end
   end
 end


### PR DESCRIPTION
It is not working in production because the path is not set correctly.

For now let's just remove it and add it back later. See #29